### PR TITLE
add cropping the map

### DIFF
--- a/lib/Tools.js
+++ b/lib/Tools.js
@@ -36,27 +36,36 @@ const Tools = {
             obstacle_strong: Jimp.rgbaToInt(82, 174, 255, 255),
             path: Jimp.rgbaToInt(255, 255, 255, 255)
         };
-        const DIMENSIONS = {
-            width: options.parsedMapData.image.dimensions.width,
-            height: options.parsedMapData.image.dimensions.height
-        };
 
         const settings = Object.assign({
             drawPath: true,
             drawCharger: true,
             drawRobot: true,
             border: 2,
-            scale: 4
+            scale: 4,
+            crop_x1: 0,
+            crop_x2: Number.MAX_VALUE,
+            crop_y1: 0,
+            crop_y2: Number.MAX_VALUE
         }, options.settings);
 
-        new Jimp(DIMENSIONS.width, DIMENSIONS.height, function (err, image) {
+        const BOUNDS = {
+            x1: Math.min(settings.crop_x1, options.parsedMapData.image.dimensions.width-1),
+            x2: Math.min(settings.crop_x2, options.parsedMapData.image.dimensions.width),
+            y1: Math.min(settings.crop_y1, options.parsedMapData.image.dimensions.height-1),
+            y2: Math.min(settings.crop_y2, options.parsedMapData.image.dimensions.height),
+        }
+
+        new Jimp(BOUNDS.x2-BOUNDS.x1, BOUNDS.y2-BOUNDS.y1, function (err, image) {
             if (!err) {
                 //Step 1: Draw Map + calculate viewport
                 Object.keys(options.parsedMapData.image.pixels).forEach(key => {
                     const color = COLORS[key];
 
                     options.parsedMapData.image.pixels[key].forEach(function drawPixel(px) {
-                        image.setPixelColor(color, px[0], px[1]);
+                        if(px[0]>= BOUNDS.x1 && px[0]<= BOUNDS.x2 && px[1]>= BOUNDS.y1 && px[1]<= BOUNDS.y2 ){
+                            image.setPixelColor(color, px[0]-BOUNDS.x1, px[1]-BOUNDS.y1);
+                        }
                     })
                 });
 
@@ -66,8 +75,8 @@ const Tools = {
                 //Step 3: Draw Path
                 const coords = options.parsedMapData.path.points.map(point => {
                     return [
-                        Math.floor((point[0]/50 - options.parsedMapData.image.position.left) * settings.scale),
-                        Math.floor((point[1]/50 - options.parsedMapData.image.position.top) * settings.scale)
+                        Math.floor((point[0]/50 - options.parsedMapData.image.position.left - BOUNDS.x1) * settings.scale),
+                        Math.floor((point[1]/50 - options.parsedMapData.image.position.top - BOUNDS.y1) * settings.scale)
                     ]});
                 let first = true;
                 let oldPathX, oldPathY; // old Coordinates
@@ -106,8 +115,8 @@ const Tools = {
                                 //Step 6: Draw Charger
                                 if (settings.drawCharger === true && options.parsedMapData.charger) {
                                     const chargerCoords = {
-                                        x: options.parsedMapData.charger[0] / 50 - options.parsedMapData.image.position.left,
-                                        y: options.parsedMapData.charger[1] / 50 - options.parsedMapData.image.position.top
+                                        x: options.parsedMapData.charger[0] / 50 - options.parsedMapData.image.position.left - BOUNDS.x1,
+                                        y: options.parsedMapData.charger[1] / 50 - options.parsedMapData.image.position.top - BOUNDS.y1
                                     };
 
                                     image.composite(
@@ -120,8 +129,8 @@ const Tools = {
                                 //Step 7: Draw Robot
                                 if (settings.drawRobot === true && options.parsedMapData.robot) {
                                     const robotCoords = {
-                                        x: options.parsedMapData.robot[0] / 50 - options.parsedMapData.image.position.left,
-                                        y: options.parsedMapData.robot[1] / 50 - options.parsedMapData.image.position.top
+                                        x: options.parsedMapData.robot[0] / 50 - options.parsedMapData.image.position.left - BOUNDS.x1,
+                                        y: options.parsedMapData.robot[1] / 50 - options.parsedMapData.image.position.top - BOUNDS.y1
                                     };
 
                                     image.composite(


### PR DESCRIPTION
Add settings to crop the map to certain bounds.
The values ​​refer to the pixel values ​​in the mapdata and not to zone coordinates.
If the settings ​​are not specified, the whole map will be rendered as before.

config.json:

```
 "mapSettings": {
      "drawPath": true,
      "drawCharger": true,
      "drawRobot": true,
      "border": 1,
      "scale": 4,
      "crop_x1": 100,
      "crop_x2": 240,
      "crop_y1": 90,
      "crop_y2": 365
    },
```

see #7, thanks to @noxhirsch  