### PR TITLE
Configurable colors and image overlay

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 package-lock.json
+config.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+package-lock.json

--- a/lib/Configuration.js
+++ b/lib/Configuration.js
@@ -1,6 +1,7 @@
 const fs = require("fs");
 const Tools = require("./Tools");
 const path = require("path");
+const Jimp = require("jimp");
 
 /**
  * @constructor
@@ -19,7 +20,13 @@ const Configuration = function() {
                 drawCharger: true,
                 drawRobot: true,
                 border: 2,
-                scale: 4
+                scale: 4,
+                colors: {
+                    floor: "#0076ff",
+                    obstacle_weak: "#6699ff",
+                    obstacle_strong: "#52aeff",
+                    path: "#ffffff"
+                  }
             },
             mapDataTopic: "valetudo/rockrobo/map_data",
             minMillisecondsBetweenMapUpdates: 10000,
@@ -40,8 +47,8 @@ const Configuration = function() {
             this.persist();
         } catch(e) {
             console.error("Invalid configuration file!");
+            console.error(e)
             console.log("Writing new file using defaults");
-
             this.persist();
         }
     } else {

--- a/lib/Tools.js
+++ b/lib/Tools.js
@@ -39,7 +39,11 @@ const Tools = {
             crop_x1: 0,
             crop_x2: Number.MAX_VALUE,
             crop_y1: 0,
-            crop_y2: Number.MAX_VALUE
+            crop_y2: Number.MAX_VALUE,
+            overlay_path: null,
+            overlay_scale: 1,
+            overlay_x: 0,
+            overlay_y: 0
         }, options.settings);
         
         // parse colors
@@ -158,6 +162,18 @@ const Tools = {
                         callback(err);
                     }
                 });
+                
+                // Step 8: Load, scale and draw overlay
+                if (settings.overlay_path) {
+                    Jimp.read(settings.overlay_path, function (err, overlayImage) {
+                        if (!err) {
+                            overlayImage.scale(settings.overlay_scale, Jimp.AUTO);
+                            image.composite(overlayImage, settings.overlay_x, settings.overlay_y);
+                        }
+                    });
+                }
+                
+                
             } else {
                 callback(err);
             }

--- a/lib/Tools.js
+++ b/lib/Tools.js
@@ -43,7 +43,11 @@ const Tools = {
             overlay_path: null,
             overlay_scale: 1,
             overlay_x: 0,
-            overlay_y: 0
+            overlay_y: 0,
+            underlay_path: null,
+            underlay_scale: 1,
+            underlay_x: 0,
+            underlay_y: 0
         }, options.settings);
         
         // parse colors
@@ -152,6 +156,7 @@ const Tools = {
                                         robotCoords.y * settings.scale - robotImage.bitmap.height / 2
                                     )
                                 }
+                                
 
                                 image.getBuffer(Jimp.AUTO, callback);
                             } else {
@@ -163,12 +168,24 @@ const Tools = {
                     }
                 });
                 
-                // Step 8: Load, scale and draw overlay
+                // Step 8: Load, scale and draw overlay image
                 if (settings.overlay_path) {
                     Jimp.read(settings.overlay_path, function (err, overlayImage) {
                         if (!err) {
                             overlayImage.scale(settings.overlay_scale, Jimp.AUTO);
                             image.composite(overlayImage, settings.overlay_x, settings.overlay_y);
+                        }
+                    });
+                }
+                
+                // Step 9: Load, scale and draw underlay image
+                if (settings.underlay_path) {
+                    Jimp.read(settings.underlay_path, function (err, underlayImage) {
+                        if (!err) {
+                            underlayImage.scale(settings.underlay_scale, Jimp.AUTO);
+                            image.composite(underlayImage, settings.underlay_x, settings.underlay_y, {
+                                mode: Jimp.BLEND_DESTINATION_OVER
+                                });
                         }
                     });
                 }

--- a/lib/Tools.js
+++ b/lib/Tools.js
@@ -31,10 +31,10 @@ const Tools = {
      */
     DRAW_MAP_PNG: function (options, callback) {
         const COLORS = {
-            floor: Jimp.rgbaToInt(0, 118, 255, 255),
-            obstacle_weak: Jimp.rgbaToInt(102, 153, 255, 255),
-            obstacle_strong: Jimp.rgbaToInt(82, 174, 255, 255),
-            path: Jimp.rgbaToInt(255, 255, 255, 255)
+            floor: Jimp.rgbaToInt(249, 249, 249, 255),
+            obstacle_weak: Jimp.rgbaToInt(255, 102, 0, 150),
+            obstacle_strong: Jimp.rgbaToInt(255, 102, 0, 255),
+            path: Jimp.rgbaToInt(40, 44, 52, 255)
         };
 
         const settings = Object.assign({

--- a/lib/Tools.js
+++ b/lib/Tools.js
@@ -30,13 +30,6 @@ const Tools = {
      * @constructor
      */
     DRAW_MAP_PNG: function (options, callback) {
-        const COLORS = {
-            floor: Jimp.rgbaToInt(249, 249, 249, 255),
-            obstacle_weak: Jimp.rgbaToInt(255, 102, 0, 150),
-            obstacle_strong: Jimp.rgbaToInt(255, 102, 0, 255),
-            path: Jimp.rgbaToInt(40, 44, 52, 255)
-        };
-
         const settings = Object.assign({
             drawPath: true,
             drawCharger: true,
@@ -48,6 +41,22 @@ const Tools = {
             crop_y1: 0,
             crop_y2: Number.MAX_VALUE
         }, options.settings);
+        
+        // parse colors
+        const defaultColors = {
+            floor: "#0076ff",
+            obstacle_weak: "#6699ff",
+            obstacle_strong: "#52aeff",
+            path: "#ffffff"
+        }
+        const confColors = Object.assign(defaultColors,
+            options.settings.colors);
+        const colors = {
+            floor: Jimp.cssColorToHex(confColors.floor),
+            obstacle_weak: Jimp.cssColorToHex(confColors.obstacle_weak),
+            obstacle_strong: Jimp.cssColorToHex(confColors.obstacle_strong),
+            path: Jimp.cssColorToHex(confColors.path)
+        };
 
         const BOUNDS = {
             x1: Math.min(settings.crop_x1, options.parsedMapData.image.dimensions.width-1),
@@ -60,7 +69,7 @@ const Tools = {
             if (!err) {
                 //Step 1: Draw Map + calculate viewport
                 Object.keys(options.parsedMapData.image.pixels).forEach(key => {
-                    const color = COLORS[key];
+                    const color = colors[key];
 
                     options.parsedMapData.image.pixels[key].forEach(function drawPixel(px) {
                         if(px[0]>= BOUNDS.x1 && px[0]<= BOUNDS.x2 && px[1]>= BOUNDS.y1 && px[1]<= BOUNDS.y2 ){
@@ -97,7 +106,7 @@ const Tools = {
                         y = oldPathY;
                         i = 1;
                         while (i <= step) {
-                            image.setPixelColor(COLORS.path, x, y);
+                            image.setPixelColor(colors.path, x, y);
                             x = x + dx;
                             y = y + dy;
                             i = i + 1;

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "i-cant-believe-its-not-valetudo",
   "version": "0.2.0",
   "dependencies": {
-    "jimp": "0.3.2",
+    "jimp": "0.9.3",
     "mqtt": "^2.18.8",
     "compression": "^1.7.2",
     "express": "^4.16.3"


### PR DESCRIPTION
This pull request includes the following changes:
* Colors are stored as CSS strings internally and are parsed by `Jimp.cssColorToHex` on rendering. All valid CSS color definitions are supported (e.g. HEX, rgba, named colors). Note: this requires a current version of Jimp.
* Map colors can be configured in the config file via the `mqtt.mapSettings.colors` object, e.g.: 

  ```json
  ...
  colors: {
    "floor": "#0076ff",
    "obstacle_weak": "#6699ff",
    "obstacle_strong": "#52aeff",
    "path": "#ffffff"
  }
  ...
  ```

  If the `colors` object is not present, the default colors are used.
* It is possible to define an overlay and underlay image for the map by using the the optional parameters `mqtt.mapSettings.overlay_path` and `mqtt.mapSettings.underlay_path`. The overlay/underlay image has to be in a [format supported by Jimp](https://github.com/oliver-moran/jimp#supported-image-types). The scale of the images can be controlled by the `mqtt.mapSettings.overlay_scale` and `mqtt.mapSettings.underlay_scale` parameters. Additionally, the images can be shifted by using the parameters `mqtt.mapSettings.overlay_x` and `mqtt.mapSettings.overlay_y` (`mqtt.mapSettings.underlay_x` and `mqtt.mapSettings.underlay_y`).

Example configuration using the new features:

```json
{
  "mqtt": {
    "identifier": "rockrobo",
    "topicPrefix": "valetudo",
    "autoconfPrefix": "homeassistant",
    "broker_url": "mqtt://mybroker",
    "caPath": "",
    "mapSettings": {
      "drawPath": true,
      "drawCharger": true,
      "drawRobot": true,
      "border": 2,
      "scale": 4,
      "crop_x1": 55,
      "crop_x2": 340,
      "crop_y1": 75,
      "crop_y2": 270,
      "colors": {
        "floor": "rgba(0,0,0,0)",
        "obstacle_weak": "rgba(0,0,0,0)",
        "obstacle_strong": "rgba(0,0,0,0.2)",
        "path": "black"
      },
      "overlay_path": "/data/walls.png",
      "overlay_scale": 1,
      "overlay_x": -8,
      "overlay_y": 8,
      "underlay_path": "/data/floors.png",
      "underlay_scale": 1,
      "underlay_x": -8,
      "underlay_y": 8
    },
    "mapDataTopic": "valetudo/rockrobo/map_data",
    "minMillisecondsBetweenMapUpdates": 10000,
    "publishMapImage": false
  },
  "webserver": {
    "enabled": true,
    "port": 3000
  }
}
```

**Important**: When upgrading an existing installation, make sure to run `npm install` before `npm start` to upgrade Jimp.

Also please ignore commit `20e7cae` ("Openhab colorscheme for map."). I included it by accident. The changes made in this commit have been made obsolete by the new configurable colors feature.