### PR TITLE
Add device section and change friendly name

### DIFF
--- a/lib/MqttClient.js
+++ b/lib/MqttClient.js
@@ -38,8 +38,9 @@ const MqttClient = function(options) {
 
     this.autoconf_payloads = {
         map: {
-            name: this.identifier + "_map",
+            name: this.identifier + " Map",
             unique_id: this.identifier + "_map",
+            device: { name: this.identifier, identifiers: [ this.identifier ] },
             topic: this.topics.map
         }
     };


### PR DESCRIPTION
Added a device section to the mqtt Home Assistant autoconfiguration so the map is put to the vacuum device.
Also make the name less id-like.

![image](https://user-images.githubusercontent.com/5469257/100465629-ee576300-30cf-11eb-8d6b-26d66883a620.png)
