### PR TITLE
Fix mqtt client not connecting when broker is behind traefik proxy

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "compression": "^1.7.2",
     "express": "^4.16.3",
     "jimp": "0.9.3",
-    "mqtt": "^2.18.8"
+    "mqtt": "^4.2.6"
   },
   "scripts": {
     "start": "node app.js"


### PR DESCRIPTION
I run an mqtt broker behind a traefik proxy. This proxy will deliver a self-signed default certificate if a request comes without a servername (SNI). Older versions of mqtt clients do not send this servername. A minimal example using the latest mqtt.js package revealed: It's all fixed by updating to a newer version.
By default, npm will install the exact version specified in the package.json so it installed 2.18.8. Editiing this to 4.2.6 fixed the SNI issue for me. Should be downward compatible and might save some headache for someone.
By the way: This is my first (and hopefully not last) pull request, so be gentle if I missed some best practices for creating pull request...
Thanks for your work!