### PR TITLE
Publish Docker images

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -20,7 +20,7 @@ jobs:
       - id: string
         uses: ASzc/change-string-case-action@v2
         with:
-          string: ${{ DOCKER_IMAGE }}
+          string: ${{ env.DOCKER_IMAGE }}
 
       - name: Docker meta
         id: docker_meta

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,59 @@
+name: Docker Publish
+
+on:  
+  workflow_dispatch:
+  push:
+    branches:
+      - master
+
+env:
+  DOCKER_IMAGE: ghcr.io/${{ github.repository }}
+
+jobs:
+  docker:
+    runs-on: ubuntu-20.04
+    steps:
+
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Docker meta
+        id: docker_meta
+        uses: crazy-max/ghaction-docker-meta@v1
+        with:
+          images: ${{ env.DOCKER_IMAGE }}
+          tag-custom: latest
+          tag-custom-only: true
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1 
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.CR_PAT }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: ${{ steps.docker_meta.outputs.tags }}
+          labels: ${{ steps.docker_meta.outputs.labels }}
+
+      - name: Image digest
+        run: echo ${{ steps.docker_build.outputs.digest }}
+
+      - name: Check manifest
+        run: |
+          docker buildx imagetools inspect ${{ env.DOCKER_IMAGE }}:${{ steps.docker_meta.outputs.version }}
+      
+      - name: Dump context
+        if: always()
+        uses: crazy-max/ghaction-dump-context@v1

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -17,11 +17,16 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - id: string
+        uses: ASzc/change-string-case-action@v2
+        with:
+          string: ${{ DOCKER_IMAGE }}
+
       - name: Docker meta
         id: docker_meta
         uses: crazy-max/ghaction-docker-meta@v1
         with:
-          images: ${{ env.DOCKER_IMAGE }}
+          images: ${{ steps.string.outputs.lowercase }}
           tag-custom: latest
           tag-custom-only: true
 
@@ -52,7 +57,7 @@ jobs:
 
       - name: Check manifest
         run: |
-          docker buildx imagetools inspect ${{ env.DOCKER_IMAGE }}:${{ steps.docker_meta.outputs.version }}
+          docker buildx imagetools inspect ${{ steps.string.outputs.lowercase }}:${{ steps.docker_meta.outputs.version }}
       
       - name: Dump context
         if: always()


### PR DESCRIPTION
Fixes #43 
Requires a secret called CR_PAT with a personal access token.
Publishes images to ghcr.io