### PR TITLE
Allow pinning the charger to a specific location

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,21 @@ interpolation.
 
 Rotating the map can be achieved by setting the `mapSettings.rotate` to the desired value.
 
+### Fixed charger
+
+If you'd like to always have the charger at a fixed location in the generated images you can
+tweak `mapSettings.fixedCharger`.
+
+First, set `enabled` to `true`, the other parameters to `null` and run the program.
+It will calculate the remaining parameters and print them to the console. You can copy them
+into the config file.
+
+If you don't copy them the charger will still stay at a fixed location, but only as long as
+the program keeps running. New values will be calculated on each startup.
+
+Note that the parameters are not relative to the final (scaled) image, but to the original
+raw map resolution.
+
 ### Colors
 
 The map is rendered using a blueish color map by default. The colors

--- a/lib/MapDrawer.js
+++ b/lib/MapDrawer.js
@@ -26,6 +26,14 @@ class MapDrawer {
         };
         this.colors = Object.assign(defaultColors,
             options.settings.colors);
+
+        this.fixedCharger = Object.assign({
+            enabled: false,
+            chargerMapPos: null,
+            chargerCroppedPos: null,
+            croppedSize: null
+        }, options.settings.fixedCharger);
+
         this.colors.floor = this.hexToRgba(this.colors.floor);
         this.colors.obstacle = this.hexToRgba(this.colors.obstacle);
         this.colors.segments = this.colors.segments.map(this.hexToRgba);
@@ -45,13 +53,38 @@ class MapDrawer {
     }
 
     updateMap(mapData) {
-        this.bounds = {
-            x1: Math.min(...mapData.layers.flatMap(layer => layer.dimensions.x.min)),
-            x2: Math.max(...mapData.layers.flatMap(layer => layer.dimensions.x.max)),
-            y1: Math.min(...mapData.layers.flatMap(layer => layer.dimensions.y.min)),
-            y2: Math.max(...mapData.layers.flatMap(layer => layer.dimensions.y.max))
+        const chargerLocation = mapData.entities.find(e => e.type === "charger_location").points.map(d => Math.floor(d / mapData.pixelSize));
+        if (this.fixedCharger.enabled && this.fixedCharger.croppedSize !== null && this.fixedCharger.chargerMapPos !== null && this.fixedCharger.chargerCroppedPos !== null) {
+            this.bounds = {
+                x1: this.fixedCharger.chargerMapPos[0] - this.fixedCharger.chargerCroppedPos[0],
+                x2: this.fixedCharger.chargerMapPos[0] - this.fixedCharger.chargerCroppedPos[0] + this.fixedCharger.croppedSize[0],
+                y1: this.fixedCharger.chargerMapPos[1] - this.fixedCharger.chargerCroppedPos[1],
+                y2: this.fixedCharger.chargerMapPos[1] - this.fixedCharger.chargerCroppedPos[1] + this.fixedCharger.croppedSize[1],
+            };
+        } else {
+            this.bounds = {
+                x1: Math.min(...mapData.layers.flatMap(layer => layer.dimensions.x.min)),
+                x2: Math.max(...mapData.layers.flatMap(layer => layer.dimensions.x.max)),
+                y1: Math.min(...mapData.layers.flatMap(layer => layer.dimensions.y.min)),
+                y2: Math.max(...mapData.layers.flatMap(layer => layer.dimensions.y.max))
+            };
+        }
+
+        this.mapData = {
+            ...mapData,
+            layers: mapData.layers.map(layer => ({...layer, pixels: this.translatePoints(layer.pixels)}))
         };
-        this.mapData = { ...mapData, layers: mapData.layers.map(layer => ({ ...layer, pixels: this.translatePoints(layer.pixels) })) };
+
+        // Compute initial fixed charger location and map size
+        if (this.fixedCharger.enabled && (this.fixedCharger.croppedSize === null || this.fixedCharger.chargerMapPos === null || this.fixedCharger.chargerCroppedPos === null)) {
+            this.fixedCharger.croppedSize = [this.bounds.x2 - this.bounds.x1, this.bounds.y2 - this.bounds.y1];
+            this.fixedCharger.chargerMapPos = chargerLocation;
+            this.fixedCharger.chargerCroppedPos = this.translatePoints(chargerLocation);
+            Logger.info("Calculated parameters for fixedCharger, adjust as needed:");
+            Logger.info("- chargerMapPos:", this.fixedCharger.chargerMapPos);
+            Logger.info("- chargerCroppedPos:", this.fixedCharger.chargerCroppedPos);
+            Logger.info("- croppedSize:", this.fixedCharger.croppedSize);
+        }
     }
 
     hexToRgba(hex) {
@@ -64,7 +97,7 @@ class MapDrawer {
             };
         } catch {
             Logger.error("Unable to parse hex color " + hex + "!");
-            return { r: 0, g: 0, b: 0, a: 255 };
+            return {r: 0, g: 0, b: 0, a: 255};
         }
     }
 
@@ -116,8 +149,13 @@ class MapDrawer {
 
         let pointsToCanvas = (coords) => coords.map(d => Math.floor(d / this.mapData.pixelSize));
 
-        const canvasWidth = Math.max.apply(undefined, this.mapData.layers.flatMap(l => l.pixels.filter((_, index) => index % 2 === 0))) + 1;
-        const canvasHeight = Math.max.apply(undefined, this.mapData.layers.flatMap(l => l.pixels.filter((_, index) => index % 2 === 1))) + 1;
+        let canvasWidth, canvasHeight;
+        if (!this.fixedCharger.enabled || this.fixedCharger.croppedSize === null) {
+            canvasWidth = Math.max.apply(undefined, this.mapData.layers.flatMap(l => l.pixels.filter((_, index) => index % 2 === 0))) + 1;
+            canvasHeight = Math.max.apply(undefined, this.mapData.layers.flatMap(l => l.pixels.filter((_, index) => index % 2 === 1))) + 1;
+        } else {
+            [canvasWidth, canvasHeight] = this.fixedCharger.croppedSize;
+        }
         const mapCanvas = Canvas.createCanvas(canvasWidth * this.settings.scale, canvasHeight * this.settings.scale);
         let ctx = mapCanvas.getContext("2d");
         if (this.settings.rotate) {
@@ -129,7 +167,7 @@ class MapDrawer {
 
         if ((!skipLayers || !this.lastLayers) && this.mapData.layers && this.mapData.layers.length) {
             this.mapData.layers.forEach(layer => {
-                let color = { r: 0, g: 0, b: 0, a: 255 };
+                let color = {r: 0, g: 0, b: 0, a: 255};
 
                 switch (layer.type) {
                     case "floor":

--- a/lib/res/default_config.json
+++ b/lib/res/default_config.json
@@ -9,6 +9,12 @@
       "floor": "#0076ff",
       "obstacle": "#52aeff",
       "path": "#ffffff"
+    },
+    "fixedCharger": {
+      "enabled": false,
+      "chargerMapPos": null,
+      "chargerCroppedPos": null,
+      "croppedSize": null
     }
   },
   "mqtt": {


### PR DESCRIPTION
I tested your suggestion of not cropping the map to size, however it does not yield very good results since, if combined with the scaling, it generates a huge canvas which crashes nodejs.

These PR changes instead allow pinning the charger to a specific location of the final image. When this is enabled the final image size is also fixed.

In order to set this up one needs to:

- Enable `fixedCharger`, without providing any offsets
- The program will run as if it weren't enabled, then calculate the offsets, print them and remember them for the current session
- The offsets can then be used in the configuration file, optionally tweaking them to add a blank gap around the image
