### PR TITLE
Update default MQTT topics

### DIFF
--- a/lib/MqttClient.js
+++ b/lib/MqttClient.js
@@ -30,13 +30,13 @@ class MqttClient {
         this.topicPrefix = options.topicPrefix || "valetudo";
         this.autoconfPrefix = options.autoconfPrefix || "homeassistant";
         this.mapSettings = options.mapSettings || {};
-        this.mapDataTopic = options.mapDataTopic || "valetudo/rockrobo/map_data";
+        this.mapDataTopic = options.mapDataTopic || "valetudo/rockrobo/MapData/map-data";
         this.minMillisecondsBetweenMapUpdates = options.minMillisecondsBetweenMapUpdates || 1000;
         this.publishMapImage = options.publishMapImage !== undefined ? options.publishMapImage : true;
 
         this.topics = {
-            map: this.topicPrefix + "/" + this.identifier + "/map",
-            homeassistant_autoconf_map: this.autoconfPrefix + "/camera/" + this.topicPrefix + "_" + this.identifier + "_map/config"
+            map: this.topicPrefix + "/" + this.identifier + "/MapData/map",
+            homeassistant_autoconf_map: this.autoconfPrefix + "/camera/" + this.identifier + "/" + this.topicPrefix + "_" + this.identifier + "_map/config"
         };
 
         this.autoconf_payloads = {

--- a/lib/res/default_config.json
+++ b/lib/res/default_config.json
@@ -17,7 +17,7 @@
     "autoconfPrefix": "homeassistant",
     "broker_url": "mqtt://user:pass@foobar.example",
     "caPath": "",
-    "mapDataTopic": "valetudo/rockrobo/map_data",
+    "mapDataTopic": "valetudo/rockrobo/MapData/map-data",
     "minMillisecondsBetweenMapUpdates": 10000,
     "publishMapImage": true
   },


### PR DESCRIPTION
This of course depends on https://github.com/Hypfer/Valetudo/pull/787

Valetudo will publish the compressed map JSON to `prefix/identifier/MapData/map-data`.

Valetudo will also optionally setup Homie autodiscovery for ICBINV for this topic: `prefix/identifier/MapData/map` (unlike hass, homie autodiscovery can't be injected externally).

As an alternative autodiscovery may be implemented but I would say it would be an overkill.