### PR TITLE
Update default config.json to use default identifier from Valetudo

### DIFF
--- a/lib/res/default_config.json
+++ b/lib/res/default_config.json
@@ -17,7 +17,7 @@
     "autoconfPrefix": "homeassistant",
     "broker_url": "mqtt://user:pass@foobar.example",
     "caPath": "",
-    "mapDataTopic": "valetudo/rockrobo/MapData/map-data",
+    "mapDataTopic": "valetudo/robot/MapData/map-data",
     "minMillisecondsBetweenMapUpdates": 10000,
     "publishMapImage": true
   },


### PR DESCRIPTION
The mqtt topic in ICBINV assumes the default vacuum identifier is rockrobo, [when it is actually robot](https://github.com/Hypfer/Valetudo/blob/eb2edaf969a175648cb0f53405b1780f0ac799d2/client/settings-mqtt.js#L75). Change ICBINV to use "robot" so new users that do not change defaults can have a working setup