### PR TITLE
Endpoint for base64-encoding

### DIFF
--- a/lib/MapDrawer.js
+++ b/lib/MapDrawer.js
@@ -215,7 +215,10 @@ class MapDrawer {
             ctx.fillRect(noGoZonePixels[0], noGoZonePixels[1], noGoZonePixels[2] - noGoZonePixels[0], noGoZonePixels[5] - noGoZonePixels[1]);
         }
 
-        return mapCanvas.toBuffer();
+        const img = mapCanvas.toBuffer();
+        const base64 = mapCanvas.toDataURL();
+
+        return {img, base64};
     }
 }
 

--- a/lib/MqttClient.js
+++ b/lib/MqttClient.js
@@ -94,13 +94,16 @@ class MqttClient {
 
             const drawStart = process.hrtime();
 
-            const img = this.mapDrawer.draw(this.skipLayers);
+            const drawn = this.mapDrawer.draw(this.skipLayers);
+            const img = drawn.img
+            const base64 = drawn.base64;
 
             const drawEnd = process.hrtime(drawStart);
 
             Logger.info("Map drawn in " + ((drawEnd[0]* 1000000000 + drawEnd[1]) / 1000000) + " ms");
 
             this.mapData.img = img;
+            this.mapData.base64 = base64;
 
             if (this.publishMapImage) {
                 this.client.publish(this.topics.map, img, { retain: true });

--- a/lib/Webserver.js
+++ b/lib/Webserver.js
@@ -27,6 +27,15 @@ class WebServer {
             }
         });
 
+        this.app.get("/api/map/base64", (req,res) => {
+            if (this.mapData && this.mapData.base64) {
+                res.contentType("text/plain");
+                res.end(this.mapData.base64);
+            } else {
+                res.sendStatus(404);
+            }
+        });
+
         this.app.get("/api/map/raw", (req,res) => {
             if (this.mapData && this.mapData.raw) {
                 res.json(this.mapData.raw);


### PR DESCRIPTION
I'm convinced  (it's kind of my white whale) that the "View the map"-workaround described at [openHAB integration](https://valetudo.cloud/pages/integrations/openhab-integration.html) doesn't work because the MapURL Image Item can't be updated with the ICantBelieveItsNotValetudo image url but with the image as base64-encoded string.

So my solution was to add a webserver endpoint api/map/base64 
(I don't publish the base64-encoding to MQTT, but this could be also added)
 
I only found old code that handled base64 for getting the map data from Valetudo but not for delivering it with ICantBelieveItsNotValetudo.

I thought the most efficient way to get the encoding was to use directly the canvas with which the MapDrawer draws the image. But therefore I had to change MapDrawer.draw() to return the image and the string.

I'm not aware of the costs of toDataURL().  Maybe this functionality should be made optional by config.json.