### PR TITLE
feat: mqtt.publishAsBase64

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,8 @@ A basic example configuration would look like this:
         "caPath": "",
         "mapDataTopic": "valetudo/robot/MapData/map-data",
         "minMillisecondsBetweenMapUpdates": 10000,
-        "publishMapImage": true
+        "publishMapImage": true,
+        "publishAsBase64": false
     },
     "webserver": {
         "enabled": false,
@@ -59,13 +60,13 @@ A basic example configuration would look like this:
 }
 ```
 
-## Integration with FHEM, ioBroker, etc
+## Integration with FHEM, ioBroker, openHAB etc
 If you set `webserver.enabled` to `true`, the map PNG will be available
 at `http://host:port/api/map/image` so you can display a map with any
 home automation software that allows fetching images from a URL.
 The map will also be available as base64-encoded string at 
 `http://host:port/api/map/base64`.
-By default, the image data is published via MQTT to `mqtt.topicPrefix/mqtt.identifier/MapData/map`.
+By default, the image data is published via MQTT to `mqtt.topicPrefix/mqtt.identifier/MapData/map`, if `mqtt.publishAsBase64` is set to `true`, the image data is published as base64-encoded string (a.e. for openHAB).
 
 
 ## Advanced Map Configuration

--- a/app.js
+++ b/app.js
@@ -24,6 +24,7 @@ if (conf.get("mqtt")) {
         mapDataTopic: conf.get("mqtt").mapDataTopic,
         minMillisecondsBetweenMapUpdates: conf.get("mqtt").minMillisecondsBetweenMapUpdates,
         publishMapImage: conf.get("mqtt").publishMapImage,
+        publishAsBase64: conf.get("mqtt").publishAsBase64,
 
         mapData: mapData
     });

--- a/lib/MqttClient.js
+++ b/lib/MqttClient.js
@@ -19,6 +19,8 @@ class MqttClient {
      * @param {string} options.mapDataTopic {string}
      * @param {number} options.minMillisecondsBetweenMapUpdates
      * @param {boolean} options.publishMapImage
+     * @param {boolean} options.publishAsBase64
+     * 
      *
      * @param {object} options.mapData
      * @class
@@ -33,6 +35,7 @@ class MqttClient {
         this.mapDataTopic = options.mapDataTopic || "valetudo/robot/MapData/map-data";
         this.minMillisecondsBetweenMapUpdates = options.minMillisecondsBetweenMapUpdates || 1000;
         this.publishMapImage = options.publishMapImage !== undefined ? options.publishMapImage : true;
+        this.publishAsBase64 = options.publishAsBase64 !== undefined ? options.publishAsBase64 : false;
 
         this.topics = {
             map: this.topicPrefix + "/" + this.identifier + "/MapData/map",
@@ -106,7 +109,8 @@ class MqttClient {
             this.mapData.base64 = base64;
 
             if (this.publishMapImage) {
-                this.client.publish(this.topics.map, img, { retain: true });
+                this.client.publish(this.topics.map, 
+                    this.publishAsBase64? base64 : img, { retain: true });
                 Logger.info("Map published.");
             }
             this.drawingMap = false;

--- a/lib/res/default_config.json
+++ b/lib/res/default_config.json
@@ -19,7 +19,8 @@
     "caPath": "",
     "mapDataTopic": "valetudo/robot/MapData/map-data",
     "minMillisecondsBetweenMapUpdates": 10000,
-    "publishMapImage": true
+    "publishMapImage": true,
+    "publishAsBase64" : false
   },
   "webserver": {
     "enabled": false,


### PR DESCRIPTION
As described in https://github.com/Hypfer/Valetudo/discussions/1169

When the new option mqtt.publishAsBase64  is true, then the map will be published to 'MapData/map' as base64-encoded string. 
Using the same topic has the adventage that the topic is already registered for Homie autodiscovery by Valetudo or already discovered by clients.
This makes the map update in openHAB far easier and doesn't harm others who still prefer the image data.