### PR TITLE
Parse the configuration correctly as the JSON string it is

### DIFF
--- a/lib/Configuration.js
+++ b/lib/Configuration.js
@@ -19,7 +19,7 @@ class Configuration {
             Logger.info("Loading configuration file:", this.location);
 
             try {
-                const config = fs.readFileSync(this.location, {"encoding": "utf-8"}).toString();
+                const config = JSON.parse(fs.readFileSync(this.location, {"encoding": "utf-8"}).toString());
 
                 this.settings = Object.assign(
                     {},

--- a/lib/Configuration.js
+++ b/lib/Configuration.js
@@ -27,7 +27,7 @@ class Configuration {
                     config
                 );
 
-                if (this.getSerializedConfig() !== config) {
+                if (this.getSerializedConfig() !== JSON.stringify(config, null, 2)) {
                     Logger.info(`Schema changes were applied to the configuration file at: ${this.location}`);
 
                     this.persist();


### PR DESCRIPTION
This fixes an issue with configuration being read as a string and then merged with the default configuration which is a map. This resulted in the configuration read from the file being converted to a map between indexes and individual characters of the string.

Fixes #73