### PR TITLE
Add support for multiple configuration instances/robots

### DIFF
--- a/app.js
+++ b/app.js
@@ -4,38 +4,43 @@ const MqttClient = require("./lib/MqttClient");
 const WebServer = require("./lib/Webserver");
 
 const conf = new Configuration();
-const mapData = {};
+const mapData = [];
 
 try {
-    Logger.LogLevel = conf.get("logLevel");
+    Logger.LogLevel = conf.get(0, "logLevel");
 } catch (e) {
     Logger.error("Initialising Logger: " + e);
 }
 
-if (conf.get("mqtt")) {
-    // eslint-disable-next-line no-unused-vars
-    const mqttClient = new MqttClient({
-        brokerURL: conf.get("mqtt").broker_url,
-        caPath: conf.get("mqtt").caPath,
-        identifier: conf.get("mqtt").identifier,
-        topicPrefix: conf.get("mqtt").topicPrefix,
-        autoconfPrefix: conf.get("mqtt").autoconfPrefix,
-        mapSettings: conf.get("mapSettings"),
-        mapDataTopic: conf.get("mqtt").mapDataTopic,
-        minMillisecondsBetweenMapUpdates: conf.get("mqtt").minMillisecondsBetweenMapUpdates,
-        publishMapImage: conf.get("mqtt").publishMapImage,
-        publishAsBase64: conf.get("mqtt").publishAsBase64,
+for (var i = 0; i < conf.getConfigCount(); i++) {
+    mapData.push({});
 
-        mapData: mapData
-    });
-
-    if (conf.get("webserver") && conf.get("webserver").enabled === true) {
+    if (conf.get(i, "mqtt")) {
         // eslint-disable-next-line no-unused-vars
-        const webServer = new WebServer({
-            port: conf.get("webserver").port,
-            mapData: mapData
+        const mqttClient = new MqttClient({
+            brokerURL: conf.get(i, "mqtt").broker_url,
+            caPath: conf.get(i, "mqtt").caPath,
+            identifier: conf.get(i, "mqtt").identifier,
+            topicPrefix: conf.get(i, "mqtt").topicPrefix,
+            autoconfPrefix: conf.get(i, "mqtt").autoconfPrefix,
+            mapSettings: conf.get(i, "mapSettings"),
+            mapDataTopic: conf.get(i, "mqtt").mapDataTopic,
+            minMillisecondsBetweenMapUpdates: conf.get(i, "mqtt").minMillisecondsBetweenMapUpdates,
+            publishMapImage: conf.get(i, "mqtt").publishMapImage,
+            publishAsBase64: conf.get(i, "mqtt").publishAsBase64,
+
+            mapData: mapData[i]
         });
+
+        if (conf.get(i, "webserver") && conf.get(i, "webserver").enabled === true) {
+            // eslint-disable-next-line no-unused-vars
+            const webServer = new WebServer({
+                port: conf.get(i, "webserver").port,
+                mapData: mapData[i]
+            });
+        }
+    } else {
+        Logger.error("Missing configuration.mqtt!");
     }
-} else {
-    Logger.error("Missing configuration.mqtt!");
+
 }

--- a/lib/Configuration.js
+++ b/lib/Configuration.js
@@ -10,7 +10,7 @@ class Configuration {
     constructor() {
         /** @private */
         this.eventEmitter = new EventEmitter();
-        this.settings = DEFAULT_SETTINGS;
+        this.settings = [DEFAULT_SETTINGS];
 
         this.location = path.join(__dirname, "../config.json");
 
@@ -19,15 +19,16 @@ class Configuration {
             Logger.info("Loading configuration file:", this.location);
 
             try {
-                const config = JSON.parse(fs.readFileSync(this.location, {"encoding": "utf-8"}).toString());
+                const configFileContent = JSON.parse(fs.readFileSync(this.location, {"encoding": "utf-8"}).toString());
+                const configArray = Array.isArray(configFileContent) ? configFileContent : [configFileContent];
 
-                this.settings = Object.assign(
+                this.settings = configArray.map(configEntry => Object.assign(
                     {},
-                    this.settings,
-                    config
-                );
+                    DEFAULT_SETTINGS,
+                    configEntry
+                ));
 
-                if (this.getSerializedConfig() !== JSON.stringify(config, null, 2)) {
+                if (this.getSerializedConfig() !== JSON.stringify(configArray, null, 2)) {
                     Logger.info(`Schema changes were applied to the configuration file at: ${this.location}`);
 
                     this.persist();
@@ -53,24 +54,33 @@ class Configuration {
         }
     }
 
+    getConfigCount() {
+        return this.settings.length;
+    }
+
     /**
+     * @param {number} configIdx
      * @param {string} key
      * @returns {*}
      */
-    get(key) {
-        return this.settings[key];
+    get(configIdx, key) {
+        this.assertConfigIndex(configIdx);
+        return this.settings[configIdx][key];
     }
 
-    getAll() {
-        return this.settings;
+    getAll(configIdx) {
+        this.assertConfigIndex(configIdx);
+        return this.settings[configIdx];
     }
 
     /**
+     * @param {number} configIdx
      * @param {string} key
      * @param {string|object} val
      */
-    set(key, val) { //TODO: set nested
-        this.settings[key] = val;
+    set(configIdx, key, val) { //TODO: set nested
+        this.assertConfigIndex(configIdx);
+        this.settings[configIdx][key] = val;
 
         this.persist();
     }
@@ -80,10 +90,24 @@ class Configuration {
     }
 
     /**
+     * @param {number} configIdx
+     * @private
+     */
+    assertConfigIndex(configIdx) {
+        if (configIdx < 0 || configIdx > this.settings.length) {
+            throw new Error("Config index is out of bounds");
+        }
+    }
+
+    /**
      * @private
      */
     getSerializedConfig() {
-        return JSON.stringify(this.settings, null, 2);
+        if (this.getConfigCount() === 1) {
+            return JSON.stringify(this.settings[0], null, 2);
+        } else {
+            return JSON.stringify(this.settings, null, 2);
+        }
     }
 }
 


### PR DESCRIPTION
## What is it?

This pull request adds support for having multiple configuration instances in one server process. This resolves several problems for people with multiple robots.
1. People using the HomeAssistant Add-On don't need to install multiple instances of the addon
2. People with multiple Robots don't need to run multiple instances of this app -> They don't need to update and monitor multiple processes

This pull request does _not_ add any breaking changes. Existing configurations will continue to work and the schema does not change for people with only one robot. For people with multiple robots it will be possible to wrap the current schema in an array and add multiple configuration instances to the file.

## Why this implementation?

The current implementation has a focus on simple maintenance for the core developers of this project. It touches neither the webserver nor the mqttClient, while still being sufficent for people with multiple robots. It is not comfortable for the users though, because multiple configs have to be written and multiple ports are being opened. Either way I think this strikes a great balance between maintainability and usage, because not very many people will be using this feature.

## What can be improved?

If you prefer other implementations or have any ideas or improvements, I am open for discussion and recommendations and hope for great team work.