### PR TITLE
Added option to specify custom clientId for the MqttClient

### DIFF
--- a/app.js
+++ b/app.js
@@ -24,6 +24,7 @@ if (conf.get("mqtt")) {
     // eslint-disable-next-line no-unused-vars
     const mqttClient = new MqttClient({
         brokerURL: conf.get("mqtt").broker_url,
+        clientId: conf.get("mqtt").clientId,
         caPath: conf.get("mqtt").caPath,
         identifier: conf.get("mqtt").identifier,
         topicPrefix: conf.get("mqtt").topicPrefix,

--- a/lib/MqttClient.js
+++ b/lib/MqttClient.js
@@ -11,6 +11,7 @@ class MqttClient {
      *
      * @param {object}options
      * @param {string} options.brokerURL
+     * @param {string} options.clientId
      * @param {string} options.caPath
      * @param {string} options.identifier
      * @param {string} options.topicPrefix
@@ -27,6 +28,7 @@ class MqttClient {
      */
     constructor(options) {
         this.brokerURL = options.brokerURL;
+        this.clientId = options.clientId ?? "";
         this.caPath = options.caPath ?? "";
         this.identifier = options.identifier ?? "rockrobo";
         this.topicPrefix = options.topicPrefix ?? "valetudo";
@@ -64,6 +66,10 @@ class MqttClient {
     connect() {
         if (!this.client || (this.client && !this.client.connected && !this.client.reconnecting)) {
             const options = {};
+            if (this.clientId) {
+                options.clientId = this.clientId;
+            }
+
             if (this.caPath) {
                 options.ca = fs.readFileSync(this.caPath);
             }

--- a/lib/res/default_config.json
+++ b/lib/res/default_config.json
@@ -16,6 +16,7 @@
     "topicPrefix": "valetudo",
     "autoconfPrefix": "homeassistant",
     "broker_url": "mqtt://user:pass@foobar.example",
+    "clientId": "",
     "caPath": "",
     "mapDataTopic": "valetudo/robot/MapData/map-data",
     "minMillisecondsBetweenMapUpdates": 10000,


### PR DESCRIPTION
Hy, i maed this pull request to allow specify a custom clientId for the MQTT client. The reason behind this that now (according to MQTT V5 specification) servers require a permanent clientId for each connected client. 
The used Mqtt.js library default bhaviour is that the client generate a unique client id for the session during each connection, so this behaviour breaks the V5 auth mechanism, to fix this i allowd to specify a permanent clientId in the config.

This PR not breaks existing installations because when the config is not specified or the value is empty the library still generate random clientId`s as before, tested locally with every mentioned scenario.

The connection is also tested and verified using the VerneMq MQTT server.