### PR TITLE
Fix "[ERROR] TypeError: Cannot read properties of undefined (reading 'r')" error

### DIFF
--- a/lib/MapDrawer.js
+++ b/lib/MapDrawer.js
@@ -248,7 +248,11 @@ class MapDrawer {
                         color = this.colors.obstacle;
                         break;
                     case "segment":
-                        color = this.colors.segments[colorFinder.getColor((layer.metaData.segmentId ?? ""))];
+                        const segmentColorIndex = colorFinder.getColor((layer.metaData.segmentId ?? ""));
+                        color = this.colors.segments[segmentColorIndex];
+                        if (!color) {
+                            color = { r: 0, g: 0, b: 0, a: 255 }; // Default color when index is out of bounds
+                        }
                         break;
                 }
 


### PR DESCRIPTION
This pull request fixes `[ERROR] TypeError: Cannot read properties of undefined (reading 'r')` error:
```
[2023-09-22T22:02:53.637Z] [INFO] Loading configuration file: /app/config.json
[2023-09-22T22:02:53.663Z] [INFO] Connecting to MQTT broker...
[2023-09-22T22:02:53.670Z] [INFO] Webserver running on port 3000
[2023-09-22T22:02:53.675Z] [INFO] Connected to MQTT broker.
[2023-09-22T22:02:53.688Z] [INFO] Rendering map...
[2023-09-22T22:02:53.725Z] [ERROR] TypeError: Cannot read properties of undefined (reading 'r')
[2023-09-22T22:03:27.614Z] [INFO] Rendering map...
[2023-09-22T22:03:27.655Z] [ERROR] TypeError: Cannot read properties of undefined (reading 'r')
[2023-09-22T22:03:27.658Z] [INFO] Skipping map render due to "minMillisecondsBetweenMapUpdates" being greater than the time since the last map update.
[2023-09-22T22:04:28.639Z] [INFO] Rendering map...
[2023-09-22T22:04:28.653Z] [ERROR] TypeError: Cannot read properties of undefined (reading 'r')
[2023-09-22T22:04:28.671Z] [INFO] Skipping map render due to "minMillisecondsBetweenMapUpdates" being greater than the time since the last map update.
[2023-09-22T22:05:29.651Z] [INFO] Rendering map...
[2023-09-22T22:05:29.665Z] [ERROR] TypeError: Cannot read properties of undefined (reading 'r')
[2023-09-22T22:05:29.682Z] [INFO] Skipping map render due to "minMillisecondsBetweenMapUpdates" being greater than the time since the last map update.
```
Which also prevents map from being rendered.

I am not certainly sure if that's the right approach to fix this issue, since I am not Javascript developer and it was modified by GPT4. Most importantly - it does work now.